### PR TITLE
Library split cleanup

### DIFF
--- a/sentenai/__init__.py
+++ b/sentenai/__init__.py
@@ -1,10 +1,5 @@
-import inspect, json, re, sys, time
-import dateutil, requests, numpy
-import pandas as pd
-from shapely.geometry import Point, Polygon
-from pandas.io.json import json_normalize
-from datetime import datetime, timedelta, tzinfo
-from multiprocessing.pool import ThreadPool
+import json
+
 from sentenai.exceptions import *
 from sentenai.utils import *
 from sentenai.api import *

--- a/sentenai/__init__.py
+++ b/sentenai/__init__.py
@@ -40,9 +40,6 @@ V = EventPath()
 def event(*args, **kwargs):
     return Switch(*args, **kwargs)
 
-def delta(seconds=0, minutes=0, hours=0, days=0, weeks=0, months=0, years=0):
-    return Delta(**locals())
-
 def ast(q):
     return json.dumps(q(), indent=4)
 

--- a/sentenai/__init__.py
+++ b/sentenai/__init__.py
@@ -1,9 +1,6 @@
 import json
 
-from sentenai.exceptions import *
-from sentenai.utils import *
-from sentenai.api import *
-from sentenai.flare import *
+from sentenai.flare import EventPath, InCircle, InPolygon, Par, Select, Span, Switch
 
 try:
     from urllib.parse import quote
@@ -21,18 +18,17 @@ LEFT, CENTER, RIGHT = range(-1, 2)
 DEFAULT = None
 
 
-#### Flare Objects
-
-
 #### Convenience Functions
-
 V = EventPath()
+
 
 def event(*args, **kwargs):
     return Switch(*args, **kwargs)
 
+
 def ast(q):
     return json.dumps(q(), indent=4)
+
 
 def select(start=None, end=None):
     """Select events from a span of time.
@@ -42,8 +38,10 @@ def select(start=None, end=None):
     end -- select events occuring before `datetime()`.
     """
     kwargs = {}
-    if start: kwargs['start'] = start
-    if end: kwargs['end'] = end
+    if start:
+        kwargs['start'] = start
+    if end:
+        kwargs['end'] = end
     return Select(**kwargs)
 
 
@@ -53,14 +51,18 @@ def span(*q, **kwargs):
     else:
         return Span(*q, **kwargs)
 
-def any_of(*q): return Par("any", q)
 
-def all_of(*q): return Par("all", q)
+def any_of(*q):
+    return Par("any", q)
+
+
+def all_of(*q):
+    return Par("all", q)
+
 
 def within_distance(km, of):
     return InCircle(of, km)
 
+
 def inside_region(poly):
     return InPolygon(poly)
-
-#### Non-Flare Objects

--- a/sentenai/__init__.py
+++ b/sentenai/__init__.py
@@ -31,10 +31,6 @@ DEFAULT = None
 
 #### Convenience Functions
 
-def stream(name, *args, **kwargs):
-    """Define a stream, possibly with a list of filter arguments."""
-    return Stream(name, kwargs.get('meta', {}), *args)
-
 V = EventPath()
 
 def event(*args, **kwargs):

--- a/sentenai/flare.py
+++ b/sentenai/flare.py
@@ -1,12 +1,20 @@
-import inspect, json, re, sys, time
-import dateutil, requests, numpy
-import pandas as pd
-from shapely.geometry import Point, Polygon
-from pandas.io.json import json_normalize
-from datetime import datetime, timedelta, tzinfo
-from multiprocessing.pool import ThreadPool
-from sentenai.exceptions import *
-from sentenai.utils import *
+import inspect
+import numpy as np
+import sys
+
+from datetime import date, datetime, timedelta
+
+from sentenai import delta  # possible circular import
+from sentenai.exceptions import FlareSyntaxError
+from sentenai.utils import iso8601, py2str
+
+try:
+    from urllib.parse import quote
+except:
+    from urllib import quote
+
+
+PY3 = sys.version_info[0] == 3
 
 
 class Flare(object):
@@ -36,11 +44,11 @@ class InPolygon(Flare):
         self.poly = poly
 
     def __call__(self):
-        vs = [{'lat': y, 'lon': x} for x, y in numpy.asarray(self.poly.exterior.coords)]
+        vs = [{'lat': y, 'lon': x} for x, y in np.asarray(self.poly.exterior.coords)]
         return {"vertices": vs}
 
-    def __str__(self): 
-        return "Polygon[{}]".format(", ".join(['{{lat: {},  lon: {}}}'.format(x, y) for x, y in fnp.asarray(self.poly.exterior.coords)]))
+    def __str__(self):
+        return "Polygon[{}]".format(", ".join(['{{lat: {},  lon: {}}}'.format(x, y) for x, y in np.asarray(self.poly.exterior.coords)]))
 
 
 
@@ -234,7 +242,7 @@ class Cond(Flare):
             val = "{}-{}-{}".format(self.val.year, self.val.month, self.val.day)
         elif isinstance(self.val, datetime):
             vt = "datetime"
-            val = iso8061(self.val)
+            val = iso8601(self.val)
         else:
             vt = 'string'
 
@@ -303,7 +311,7 @@ class Stream(object):
                 sub = True
             elif sf[4] and 'Serial' in sf[4][0]:
                 sub = True
-        if sub and val: 
+        if sub and val:
             return val
         else:
             if not self._filters:
@@ -674,4 +682,3 @@ def merge(s1, s2):
     else:
         s3._width = s2._width
     return s3
-

--- a/sentenai/flare.py
+++ b/sentenai/flare.py
@@ -4,7 +4,6 @@ import sys
 
 from datetime import date, datetime, timedelta
 
-from sentenai import delta  # possible circular import
 from sentenai.exceptions import FlareSyntaxError
 from sentenai.utils import iso8601, py2str
 
@@ -15,6 +14,10 @@ except:
 
 
 PY3 = sys.version_info[0] == 3
+
+
+def delta(seconds=0, minutes=0, hours=0, days=0, weeks=0, months=0, years=0):
+    return Delta(**locals())
 
 
 class Flare(object):

--- a/sentenai/flare.py
+++ b/sentenai/flare.py
@@ -663,6 +663,10 @@ class Delta(Flare):
         return r or {'seconds': 0}
 
 
+def stream(name, *args, **kwargs):
+    """Define a stream, possibly with a list of filter arguments."""
+    return Stream(name, kwargs.get('meta', {}), *args)
+
 def merge(s1, s2):
     s3 = Span(*s2.query)
     if s1._within is None or s2._within is None:

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,4 @@
-
-from setuptools import setup, find_packages
-from codecs import open
-from os import path
-
+from setuptools import setup
 
 setup(
     name='sentenai',
@@ -37,4 +33,3 @@ setup(
     data_files=[],
     entry_points={},
 )
-


### PR DESCRIPTION
- removed unused imports
- changed * imports to explicit imports
- removed unused variables
- fixed incorrect references to numpy and iso8601
- moved functions `stream()` and `delta()` that are defined in `__init__.py`, but referenced by the submodules that it imports

I'm not confident about the last item since they are also exposed by the library via `__all__`