### PR TITLE
Add new projection capabilities.

### DIFF
--- a/sentenai/flare.py
+++ b/sentenai/flare.py
@@ -101,7 +101,7 @@ class ProjMath(Projection):
                 raise FlareSyntaxError("projection math with non-numeric types is unsupported.")
             return {'stream': self.stream(), 'projection': nd}
 
-        return [{'op': self.op, 'lhs': convert(self.lhs), 'rhs': convert(self.rhs)}]
+        return {'op': self.op, 'lhs': convert(self.lhs), 'rhs': convert(self.rhs)}
 
 
 class Returning(object):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='sentenai',
-    version='0.4.0.1',
+    version='0.4.1.0',
     description='Client library for Sentenai',
     long_description="",
     url='https://github.com/sentenai/py-sentenai',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='sentenai',
-    version='0.4.0.0',
+    version='0.4.0.1',
     description='Client library for Sentenai',
     long_description="",
     url='https://github.com/sentenai/py-sentenai',

--- a/tests/flare/test_ast.py
+++ b/tests/flare/test_ast.py
@@ -367,7 +367,7 @@ def test_returning():
             'explicit': [{
                 'stream': {'name': 'weather'},
                 'projection': {
-                    'value': [{'var': ('maxTemp',)}],
+                    'value': [{'var': ('event', 'maxTemp')}],
                     'other': {'constant': [{'lit': {'val': 3, 'type': 'int'}}]}
                 }
             }],


### PR DESCRIPTION
This commit adds basic support for math in projections and prepares projections for a minor API change ("event" must now be the first part of the path because we now support projecting top level stuff like "ts" on the corona side).

`V.foo + 50` will now do the right thing, as will `/`, `*`, `-` on both literals and paths. These operations only work on numeric types.

Or is not yet supported (`NotImplemented`).