### PR TITLE
drop_stream_names by default

### DIFF
--- a/sentenai/api.py
+++ b/sentenai/api.py
@@ -794,7 +794,7 @@ class FrameGroup(object):
         Return a generator of dataframes with one dataframe per
         found result.
         """
-        drop_prefixes = kwargs.get('drop_stream_names', False)
+        drop_prefixes = kwargs.get('drop_stream_names', True)
 
         def cname(stream, path):
             return "{}:{}".format(stream['name'], ".".join(path[1:]))


### PR DESCRIPTION
fixes #36

@xnomagichash should we stick with this naming? i feel like it's rare that you'll want the stream name prefixes, so we probably shouldn't stress about it too much.