### PR TITLE
remove extraneous "type": "span" from filters and switches

### DIFF
--- a/sentenai/flare.py
+++ b/sentenai/flare.py
@@ -519,7 +519,7 @@ class Cond(Flare):
             vt = 'string'
 
         d = {'op': op, 'arg': {'type': vt, 'val': val}}
-        if self.path.stream:
+        if isinstance(self.path, StreamPath):
             d['type'] = 'span'
         if stream:
             stream = copy(stream)

--- a/tests/flare/test_ast.py
+++ b/tests/flare/test_ast.py
@@ -315,8 +315,8 @@ def test_or_stream_filters():
                 'filter': {
                     'expr': '||',
                     'args': [
-                        {'op': '==', 'arg': {'type': 'string', 'val': 'summer'}, 'type': 'span', 'path': ('event', 'season')},
-                        {'op': '==', 'arg': {'type': 'string', 'val': 'winter'}, 'type': 'span', 'path': ('event', 'season')}
+                        {'op': '==', 'arg': {'type': 'string', 'val': 'summer'}, 'path': ('event', 'season')},
+                        {'op': '==', 'arg': {'type': 'string', 'val': 'winter'}, 'path': ('event', 'season')}
                     ]
                 }
             }
@@ -337,13 +337,11 @@ def test_switches():
                 {
                     "op": "<",
                     "arg": { "type": "double", "val": 0 },
-                    "type": "span",
                     "path": ( "event", "x" )
                 },
                 {
                     "op": ">",
                     "arg": { "type": "double", "val": 0 },
-                    "type": "span",
                     "path": ( "event", "x" )
                 }
             ]


### PR DESCRIPTION
fixes #34 

i initially was only intending to fix filters, but when i improved that `if` statement, a switches test started breaking. i ran this locally to check what the intended switches AST would look like:

```
$ flarec -q 'select (stream "S"):(x < 0 -> x > 0)' -d Core@json
```

sure enough, we don't need `"type": "span"` there either.

the core problem here is that both `StreamPath` and `EventPath` implement `__getattr__`, so looking at `self.path.stream` always returns some instance. looking at the type of `self.path` is far more reliable.