### PR TITLE
uploader improvements

### DIFF
--- a/sentenai/api.py
+++ b/sentenai/api.py
@@ -107,7 +107,7 @@ class Uploader(object):
             data = data.get()
         else:
             data = self.pool.map(process, self.iterator)
-        return { 'saved': len(data), 'failed': filter(None, data) }
+        return { 'saved': self.succeeded, 'failed': list(filter(None, data)) }
 
 
     def validate(self, data):

--- a/sentenai/api.py
+++ b/sentenai/api.py
@@ -106,7 +106,7 @@ class Uploader(object):
             #data.wait()
             data = data.get()
         else:
-            data = self.pool.map(process, list(self.iterator))
+            data = self.pool.map(process, self.iterator)
         return { 'saved': len(data), 'failed': filter(None, data) }
 
 


### PR DESCRIPTION
coercing `self.iterator` to a `list` defeats the purpose of supporting any iterable. we're still coercing it to a `list` when `progress == True` since we want the `len` to render a progress bar.

before, `saved` was returning full `len(data)` instead of just `self.succeeded.

`failed` was a `filter` but now it's a `list` for easier readability.

partially addresses https://github.com/Sentenai/py-sentenai/issues/38