### PR TITLE
allow iso timestamp string in uploaded data

### DIFF
--- a/sentenai/api.py
+++ b/sentenai/api.py
@@ -24,6 +24,11 @@ if not PY3:
 else:
     from queue import Queue
 
+if PY3:
+    string_types = str
+else:
+    string_types = basestring
+
 try:
     from urllib.parse import quote
 except:
@@ -113,6 +118,8 @@ class Uploader(object):
     def validate(self, data):
         ts = data.get('ts')
         try:
+            if isinstance(ts, string_types):
+                ts = cts(ts)
             if not ts.tzinfo:
                 ts = pytz.utc.localize(ts)
         except:


### PR DESCRIPTION
fixes #39

i'm [under the impression](https://stackoverflow.com/a/23692403) that we need the `PY3` check to properly handle unicode strings.