### PR TITLE
remove Sentenai.debug method

### DIFF
--- a/sentenai/api.py
+++ b/sentenai/api.py
@@ -185,11 +185,6 @@ class Sentenai(object):
             self.auth_key, self.host)
 
 
-    def debug(self, protocol="http", host="localhost", port=3000):
-        self.host = protocol + "://" + host + ":" + str(port)
-        return self
-
-
     def delete(self, stream, eid):
         """Delete event from a stream by its unique id.
 


### PR DESCRIPTION
This method was made to deal with a legacy design decision.