### PR TITLE
take "start" or DTMIN instead of get("start", DTMIN) to better handle None

### DIFF
--- a/sentenai/api.py
+++ b/sentenai/api.py
@@ -731,7 +731,7 @@ class Cursor(object):
             else:
                 spans = []
             for sp in spans:
-                start, end, cur = sp.get('start', DTMIN), sp.get('end', DTMAX), sp['cursor']
+                start, end, cur = sp.get('start') or DTMIN, sp.get('end') or DTMAX, sp['cursor']
                 data = self._slice(cur, start, end + horizon)
                 fr = df(start, data)
                 fr = {k: fr[k].set_index(keys=['.ts'])


### PR DESCRIPTION
the default value in a `get` call only gets used if the key isn't defined in the dict. `_slice` is assuming you're providing a `start` and `end` and blows up if either are `None`

```py
> sp = {'start': None}
> sp.get('start', 'some default')
None
> sp.get('start') or 'some default'
'some default'
```