### PR TITLE
define Cursor#list for accessing event Dicts on a per-span basis

### DIFF
--- a/sentenai/api.py
+++ b/sentenai/api.py
@@ -551,13 +551,15 @@ class Cursor(object):
                          },
                           ...]
         """
+        return json.dumps(self.events(), default=dts, indent=4)
+
+    def list(self):
         self.spans()
         pool = self.pool
         if not pool:
             return json.dumps([])
         try:
-            data = pool.map(lambda s: self._slice(s['cursor'], s.get('start') or DTMIN, s.get('end') or DTMAX), self._spans)
-            return json.dumps(data, default=dts, indent=4)
+            return pool.map(lambda s: self._slice(s['cursor'], s.get('start') or DTMIN, s.get('end') or DTMAX), self._spans)
         finally:
             pool.close()
 


### PR DESCRIPTION
fixes #53 

@xnomagichash what do you think of naming it `list()`? 

at first, i was thinking `events()`, but really, it returns a list of spans where each span specifies the events it contains. this feels similar to `dataframe()`...except we're returning a list.