### PR TITLE
Upgrade Requests to 2.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pytest==3.1.3
 pytest-cov==2.5.1
 python-dateutil==2.6.1
 pytz==2017.2
-requests==2.18.1
+requests==2.20.0
 requests-mock==1.3.0
 Shapely==1.5.17
 simplegeneric==0.8.1


### PR DESCRIPTION
A vulnerability exists in previous versions.

CVE-2018-18074
moderate severity

Vulnerable versions: <= 2.19.1
Patched version: 2.20.0

The Requests package through 2.19.1 before 2018-09-14 for Python sends
an HTTP Authorization header to an http URI upon receiving a
same-hostname https-to-http redirect, which makes it easier for remote
attackers to discover credentials by sniffing the network.

All tests passed. 