### PR TITLE
More robust pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 test:
-	PYTHONPATH=. py.test --cov-config=.coveragerc --cov=sentenai --cov-report=term tests/
+	PYTHONPATH=. python -m pytest --cov-config=.coveragerc --cov=sentenai --cov-report=term tests/
 
 test-html:
-	PYTHONPATH=. py.test --cov-config=.coveragerc --cov=sentenai --cov-report=html tests/
+	PYTHONPATH=. python -m pytest --cov-config=.coveragerc --cov=sentenai --cov-report=html tests/

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pytest==3.1.3
 pytest-cov==2.5.1
 python-dateutil==2.6.1
 pytz==2017.2
-requests==2.18.1
+requests==2.20.0
 requests-mock==1.3.0
 Shapely==1.5.17
 simplegeneric==0.8.1


### PR DESCRIPTION
Robustify the Makefiles test target
    
For whatever reason, py.test couldn't be found even though
pytest was installed. A few reports of this exist on the web;
however, I didn't really care to figure it out.
    
Use `python -m pytest...` instead of calling `py.test`
